### PR TITLE
Use build profile to enable RTEMS cross build

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,9 @@
-busy (1.6.1-1) UNRELEASED; urgency=medium
+busy (1.6.1-1) unstable; urgency=medium
 
+  [ mdavidsaver ]
   * initial
 
- --  mdavidsaver <mdavidsaver@gmail.com>  Thu, 10 Mar 2016 14:44:39 -0500
+  [ Martin Konrad ]
+  * Use build profile to enable RTEMS cross build
+
+ -- Martin Konrad <konrad@frib.msu.edu>  Thu, 13 Sep 2018 14:30:58 -0400

--- a/debian/control
+++ b/debian/control
@@ -2,17 +2,17 @@ Source: busy
 Section: libdevel
 Priority: extra
 Maintainer: mdavidsaver <mdavidsaver@gmail.com>
-Build-Depends: debhelper (>= 9), epics-debhelper (>= 8.14~),
-               epics-dev,
-               rtems-epics-mvme2100,
-               rtems-epics-mvme3100,
-               rtems-epics-mvme5500,
-               rtems-epics-pc386,
+Build-Depends: debhelper (>= 9.20141010), dpkg-dev (>= 1.17.14),
+               epics-debhelper (>= 8.14~), epics-dev,
+               rtems-epics-mvme2100 <pkg.epics-base.rtems>,
+               rtems-epics-mvme3100 <pkg.epics-base.rtems>,
+               rtems-epics-mvme5500 <pkg.epics-base.rtems>,
+               rtems-epics-pc386 <pkg.epics-base.rtems>,
                epics-asyn-dev,
-               rtems-asyn-mvme2100,
-               rtems-asyn-mvme3100,
-               rtems-asyn-mvme5500,
-               rtems-asyn-pc386,
+               rtems-asyn-mvme2100 <pkg.epics-base.rtems>,
+               rtems-asyn-mvme3100 <pkg.epics-base.rtems>,
+               rtems-asyn-mvme5500 <pkg.epics-base.rtems>,
+               rtems-asyn-pc386 <pkg.epics-base.rtems>,
 XS-Rtems-Build-Depends: rtems-epics, rtems-asyn,
 Standards-Version: 3.9.6
 Homepage: http://aps.anl.gov/bcda/synApps/busy/busy.html
@@ -42,6 +42,7 @@ Description: Binary record for wait for long operations
  This package contains runtime libraries
 
 Package: rtems-busy-mvme2100
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: epics-busy-dev (>= ${source:Version}),
          epics-busy-dev (<< ${source:Version}.1~),
@@ -54,6 +55,7 @@ Description: Binary record for wait for long operations
  This package contains support for the MVME2100 VME SBC
 
 Package: rtems-busy-mvme3100
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: epics-busy-dev (>= ${source:Version}),
          epics-busy-dev (<< ${source:Version}.1~),
@@ -66,6 +68,7 @@ Description: Binary record for wait for long operations
  This package contains support for the MVME3100 VME SBC
 
 Package: rtems-busy-mvme5500
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: epics-busy-dev (>= ${source:Version}),
          epics-busy-dev (<< ${source:Version}.1~),
@@ -78,6 +81,7 @@ Description: Binary record for wait for long operations
  This package contains support for the MVME5500 VME SBC
 
 Package: rtems-busy-pc386
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: epics-busy-dev (>= ${source:Version}),
          epics-busy-dev (<< ${source:Version}.1~),

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -1,0 +1,12 @@
+busy source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-busy-mvme2100
+busy source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-busy-mvme3100
+busy source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-busy-mvme5500
+busy source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-busy-pc386
+busy source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-epics-mvme2100 <pkg.epics-base.rtems>]
+busy source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-epics-mvme3100 <pkg.epics-base.rtems>]
+busy source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-epics-mvme5500 <pkg.epics-base.rtems>]
+busy source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-epics-pc386 <pkg.epics-base.rtems>]
+busy source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-asyn-mvme2100 <pkg.epics-base.rtems>]
+busy source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-asyn-mvme3100 <pkg.epics-base.rtems>]
+busy source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-asyn-mvme5500 <pkg.epics-base.rtems>]
+busy source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-asyn-pc386 <pkg.epics-base.rtems>]


### PR DESCRIPTION
This allows facilities that do not use RTEMS to get rid of the complexity of building this package's RTEMS dependencies. Set the environment variable `DEB_BUILD_PROFILES=pkg.epics-base.rtems` when compiling to enable the RTEMS build.